### PR TITLE
Initialize x and y values to x0 and y0 in entangle()

### DIFF
--- a/nikon/ls_sec/entangle.cc
+++ b/nikon/ls_sec/entangle.cc
@@ -48,7 +48,7 @@ uint64_t entangle(const std::vector<uint64_t> &elements) noexcept {
   uint32_t x0 = 0x1020304;
   uint32_t y0 = 0x5060708;
 
-  uint32_t x, y;
+  uint32_t x = x0, y = y0;
   for (const uint64_t &elem : elements) {
     printf("entangle 1. (%#016lx, %#016x, %#016x)\n", elem, x, y);
     //x = __bswap_32(elem & std::numeric_limits<uint32_t>::max()) ^ x;


### PR DESCRIPTION
Changes in commit 1496fed broke entangle() function. x and y values not only left unitialized and contain random RAM data on every run, but also should not be zero.